### PR TITLE
Adds socks proxy support (via requests)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
 		'Programming Language :: Python :: 3.6',
 	],
 	packages = ['snscrape', 'snscrape.modules'],
-	install_requires = ['requests', 'lxml', 'beautifulsoup4'],
+	install_requires = ['requests[socks]', 'lxml', 'beautifulsoup4'],
 	entry_points = {
 		'console_scripts': [
 			'snscrape = snscrape.cli:main',


### PR DESCRIPTION
Later versions of the python requests library supports proxy settings via environment variables. But to support socks proxy settings the [correct version of the requests library](http://docs.python-requests.org/en/master/user/advanced/#socks) needs to be installed. Fixes #27. 