### PR TITLE
Extract more information on Twitter places

### DIFF
--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -43,6 +43,10 @@ class Tweet(snscrape.base.Item):
 	mentionedUsers: typing.Optional[typing.List['User']] = None
 	coordinates: typing.Optional['Coordinates'] = None
 	place: typing.Optional[str] = None
+	place_name: typing.Optional[str] = None
+	place_type: typing.Optional[str] = None
+	country: typing.Optional[str] = None
+	country_code: typing.Optional[str] = None
 
 	username = snscrape.base._DeprecatedProperty('username', lambda self: self.user.username, 'user.username')
 	outlinksss = snscrape.base._DeprecatedProperty('outlinksss', lambda self: ' '.join(self.outlinks), 'outlinks')
@@ -378,7 +382,12 @@ class TwitterAPIScraper(snscrape.base.Scraper):
 			if (coords := tweet['geo']['coordinates']) and len(coords) == 2:
 				kwargs['coordinates'] = Coordinates(coords[1], coords[0])
 		if tweet.get('place'):
+			# get place data
 			kwargs['place'] = tweet['place']['full_name']
+			kwargs['place_name'] = tweet['place']['name']
+			kwargs['place_type'] = tweet['place']['place_type']
+			kwargs['country'] = tweet['place']['country']
+			kwargs['country_code'] = tweet['place']['country_code']
 			if 'coordinates' not in kwargs and tweet['place']['bounding_box'] and (coords := tweet['place']['bounding_box']['coordinates']) and coords[0] and len(coords[0][0]) == 2:
 				# Take the first (longitude, latitude) couple of the "place square"
 				kwargs['coordinates'] = Coordinates(coords[0][0][0], coords[0][0][1])

--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -42,11 +42,7 @@ class Tweet(snscrape.base.Item):
 	quotedTweet: typing.Optional['Tweet'] = None
 	mentionedUsers: typing.Optional[typing.List['User']] = None
 	coordinates: typing.Optional['Coordinates'] = None
-	place: typing.Optional[str] = None
-	place_name: typing.Optional[str] = None
-	place_type: typing.Optional[str] = None
-	country: typing.Optional[str] = None
-	country_code: typing.Optional[str] = None
+	place: typing.Optional['Place'] = None
 
 	username = snscrape.base._DeprecatedProperty('username', lambda self: self.user.username, 'user.username')
 	outlinksss = snscrape.base._DeprecatedProperty('outlinksss', lambda self: ' '.join(self.outlinks), 'outlinks')
@@ -101,6 +97,15 @@ class DescriptionURL:
 class Coordinates:
 	longitude: float
 	latitude: float
+
+
+@dataclasses.dataclass
+class Place:
+	fullName: str
+	name: str
+	type: str
+	country: str
+	countryCode: str
 
 
 @dataclasses.dataclass
@@ -382,12 +387,7 @@ class TwitterAPIScraper(snscrape.base.Scraper):
 			if (coords := tweet['geo']['coordinates']) and len(coords) == 2:
 				kwargs['coordinates'] = Coordinates(coords[1], coords[0])
 		if tweet.get('place'):
-			# get place data
-			kwargs['place'] = tweet['place']['full_name']
-			kwargs['place_name'] = tweet['place']['name']
-			kwargs['place_type'] = tweet['place']['place_type']
-			kwargs['country'] = tweet['place']['country']
-			kwargs['country_code'] = tweet['place']['country_code']
+			kwargs['place'] = Place(tweet['place']['full_name'], tweet['place']['name'], tweet['place']['place_type'], tweet['place']['country'], tweet['place']['country_code'])
 			if 'coordinates' not in kwargs and tweet['place']['bounding_box'] and (coords := tweet['place']['bounding_box']['coordinates']) and coords[0] and len(coords[0][0]) == 2:
 				# Take the first (longitude, latitude) couple of the "place square"
 				kwargs['coordinates'] = Coordinates(coords[0][0][0], coords[0][0][1])


### PR DESCRIPTION
While building dash maps, attributes like the country name/code could be useful. So, I added that aside from the place name the tweets scrapper also includes the country name, country code and the place name.