### PR TITLE
Fix Vkontakte-user module crash on users with millions of followers

### DIFF
--- a/snscrape/modules/vkontakte.py
+++ b/snscrape/modules/vkontakte.py
@@ -347,9 +347,11 @@ class VKontakteUserScraper(snscrape.base.Scraper):
 			if websites:
 				kwargs['websites'] = websites
 
-		def parse_num(s):
+		def parse_num(s: str) -> int:
 			if s.endswith('K'):
 				return int(s[:-1]) * 1000, 1000
+			elif s.endswith('M'):
+				return int(float(s[:-1]) * 1000000), 1000000
 			else:
 				return int(s.replace(',', '')), 1
 

--- a/snscrape/modules/vkontakte.py
+++ b/snscrape/modules/vkontakte.py
@@ -347,11 +347,15 @@ class VKontakteUserScraper(snscrape.base.Scraper):
 			if websites:
 				kwargs['websites'] = websites
 
-		def parse_num(s: str) -> int:
+		def parse_num(s: str) -> typing.Tuple[int, int]:
 			if s.endswith('K'):
 				return int(s[:-1]) * 1000, 1000
 			elif s.endswith('M'):
-				return int(float(s[:-1]) * 1000000), 1000000
+				baseNum = s[:-1]
+				precision = 1000000
+				if '.' in s:
+					precision //= (10 ** len(baseNum.split('.')[1]))
+				return int(float(baseNum) * 1000000), precision
 			else:
 				return int(s.replace(',', '')), 1
 


### PR DESCRIPTION
Hello,

We have come across the following crash:

```
Traceback (most recent call last):
  File "/tmp/snsScrapeTest/snsENV/bin/snscrape", line 8, in <module>
    sys.exit(main())
  File "/tmp/snsScrapeTest/snsENV/lib/python3.9/site-packages/snscrape/_cli.py", line 300, in main
    if args.withEntity and (entity := scraper.entity):
  File "/usr/lib/python3.9/functools.py", line 969, in __get__
    val = self.func(instance)
  File "/tmp/snsScrapeTest/snsENV/lib/python3.9/site-packages/snscrape/base.py", line 162, in entity
    return self._get_entity()
  File "/tmp/snsScrapeTest/snsENV/lib/python3.9/site-packages/snscrape/modules/vkontakte.py", line 358, in _get_entity
    count, granularity = parse_num(a.find('div', class_ = 'count').text)
  File "/tmp/snsScrapeTest/snsENV/lib/python3.9/site-packages/snscrape/modules/vkontakte.py", line 354, in parse_num
    return int(s.replace(',', '')), 1
ValueError: invalid literal for int() with base 10: '2.2M'
```
From our debugging, it seems that the crash occurs at the following code segment (line 350, vkontakte.py):
```
def parse_num(s):
    if s.endswith('K'):
        return int(s[:-1]) * 1000, 1000
    else:
        return int(s.replace(',', '')), 1
```
The function checks for followers up to the thousands, however some people have millions of followers.

We have changed the code as follows, to fix this issue:
```
def parse_num(s: str) -> int:
    if s.endswith('K'):
        return int(s[:-1]) * 1000, 1000
    elif s.endswith('M'):
        return int(float(s[:-1]) * 1000000), 1000000
    else:
        return int(s.replace(',', '')), 1
```

With the proposed changes, the code seems to perform as expected. We are not very familiar with vkontakte however, so we are not sure of the quality / completeness of this change.

Please review the proposed change and let us know if it looks good.
