### PR TITLE
fix(vkontakte): update photo detection

### DIFF
--- a/snscrape/modules/vkontakte.py
+++ b/snscrape/modules/vkontakte.py
@@ -117,6 +117,9 @@ class VKontakteUserScraper(snscrape.base.Scraper):
 			return urllib.parse.unquote(a['href'][13 : end])
 		return None
 
+	def is_photo(self, a):
+		return 'aria-label' in a.attrs and a.attrs['aria-label'].startswith('photo')
+
 	def _date_span_to_date(self, dateSpan):
 		if not dateSpan:
 			return None
@@ -172,7 +175,7 @@ class VKontakteUserScraper(snscrape.base.Scraper):
 		   not (not isCopy and thumbsDiv.parent.name == 'div' and 'class' in thumbsDiv.parent.attrs and 'copy_quote' in thumbsDiv.parent.attrs['class']): # Skip post quotes
 			photos = []
 			for a in thumbsDiv.find_all('a', class_ = 'page_post_thumb_wrap'):
-				if 'data-photo-id' not in a.attrs and 'data-video' not in a.attrs:
+				if not self.is_photo(a) and 'data-video' not in a.attrs:
 					_logger.warning(f'Skipping non-photo and non-video thumb wrap on {url}')
 					continue
 				if 'data-video' in a.attrs:


### PR DESCRIPTION
Photo scraping doesn't currently work for VKontakte, because `data-photo-id` seems no longer included in the anchor's attributes. 

There is, however, and aria-label that starts with `photo` included in the attributes; we can use that to detect whether we are dealing with a photo. Doing so allows the existing logic to scrape the URLs again :).

This should close #471.