### PR TITLE
Handle tweets that contain card info with no category

### DIFF
--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -421,9 +421,9 @@ class UnifiedCardApp:
 	type: str
 	id: str
 	title: str
-	category: str
 	countryCode: str
 	url: str
+	category: typing.Optional[str] = None
 	description: typing.Optional[str] = None
 	iconMediumKey: typing.Optional[UnifiedCardMediumKey] = None
 	size: typing.Optional[int] = None
@@ -1237,7 +1237,8 @@ class _TwitterAPIScraper(snscrape.base.Scraper):
 						vKwargs['title'] = var['title']['content']
 						if 'description' in var:
 							vKwargs['description'] = var['description']['content']
-						vKwargs['category'] = var['category']['content']
+						if 'category' in var:
+							vKwargs['category'] = var['category']['content']
 						if (ratings := var['ratings']):
 							vKwargs['ratingAverage'] = var['ratings']['star']
 							vKwargs['ratingCount'] = var['ratings']['count']


### PR DESCRIPTION
Upon encountering a tweet with values for app_store_data, a new UnifiedCardApp is created.

The current code will occasionally crash at this point on a small number of tweets with the following error:

``` 
snscrape twitter-tweet 1591904001188155393
Traceback (most recent call last):
  File "snscrape\_cli.py", line 116, in _dump_locals_on_exception
    yield
  File "snscrape\_cli.py", line 318, in main
    for i, item in enumerate(scraper.get_items(), start = 1):
  File "snscrape\modules\twitter.py", line 1665, in get_items
    yield self._graphql_timeline_tweet_item_result_to_tweet(entry['content']['itemContent']['tweet_results']['result'])
  File "snscrape\modules\twitter.py", line 1294, in _graphql_timeline_tweet_item_result_to_tweet
    kwargs['quotedTweet'] = self._graphql_timeline_tweet_item_result_to_tweet(result['quoted_status_result']['result'])
  File "snscrape\modules\twitter.py", line 1303, in _graphql_timeline_tweet_item_result_to_tweet
    kwargs['card'] = self._make_card(result['card'], _TwitterAPIType.GRAPHQL, self._get_tweet_id(tweet))
  File "snscrape\modules\twitter.py", line 1240, in _make_card
    vKwargs['category'] = var['category']['content']
KeyError: 'category'
```

The reason for the crash is fairly straightfoward- the current code assumes that a category will be assigned to each value, when in reality a category may or may not be included in the data.

See tweet 1591904001188155393 for an example of a tweet where only 2 out of 3 values have a category included.

This fix changes the 'category' param of UnifiedCardApp to an optional one.