### PR TITLE
Avoid infinite loops.

### DIFF
--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -1453,7 +1453,10 @@ class TwitterSearchScraper(_TwitterAPIScraper):
 			del paginationParams['tweet_search_mode']
 
 		for obj in self._iter_api_data('https://api.twitter.com/2/search/adaptive.json', _TwitterAPIType.V2, params, paginationParams, cursor = self._cursor):
-			yield from self._v2_timeline_instructions_to_tweets(obj)
+			if len(obj['globalObjects']['tweets']) != 0:
+				yield from self._v2_timeline_instructions_to_tweets(obj)
+			else:
+				break
 
 	@classmethod
 	def _cli_setup_parser(cls, subparser):


### PR DESCRIPTION
I thought about this issue. https://github.com/JustAnotherArchivist/snscrape/issues/636
I see, if empty tweets are returned at random and pagination is also random, I can wait, but it seems that this is not the case. It was hard for me to wait for the page to finish if it was very long.
Wouldn't a change like this PR, for example, be a good thing? 
Wdyt?