### PR TITLE
twitter: Fix to KeyError & TweetTombstone

### DIFF
--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -1413,8 +1413,11 @@ class _TwitterAPIScraper(snscrape.base.Scraper):
 				except KeyError as e:
 					_logger.warning(f"KeyError {e} in {json.dumps(entry)}")
 				except snscrape.base.ScraperException as e:
-					if str(e) != "Unknown result type 'TweetTombstone'":
+					if str(e) == "Unknown result type 'TweetTombstone'":
+						_logger.warning(f"{e} in {json.dumps(entry)}")
+					else:
 						raise e
+						
 
 	def _render_text_with_urls(self, text, urls):
 		if not urls:


### PR DESCRIPTION
Hi. This PR contains a solution so that collecting tweets from the profile does not stop at these errors:
1) https://github.com/JustAnotherArchivist/snscrape/issues/603
2) fix for various KeyError errors
3) logger typo fix

Small script to test:
```python
import snscrape.modules.twitter as sntwitter
from collections import defaultdict


def main():
    uids = [
        366842064,  # tweet, KeyError: 'legacy'
        1154011190298910720,  # Unknown result type 'TweetTombstone'
    ]

    stats = defaultdict(int)
    for uid in uids:
        print(f"* {uid} ".ljust(60, "-"))

        rep = sntwitter.TwitterProfileScraper(uid).get_items()
        for i, x in enumerate(rep, 1):
            print(f"- {uid} {i} collected") if i % 500 == 0 else None
            stats[uid] += 1

    print(stats)


if __name__ == "__main__":
    main()
```