### PR TITLE
Twitter: change fullUrl to use 'orig' instead of 'large'

### DIFF
--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -957,7 +957,7 @@ class _TwitterAPIScraper(snscrape.base.Scraper):
 				return
 			mKwargs = {
 				'previewUrl': f'{baseUrl}?format={format}&name=small',
-				'fullUrl': f'{baseUrl}?format={format}&name=large',
+				'fullUrl': f'{baseUrl}?format={format}&name=orig',
 			}
 			if medium.get('ext_alt_text'):
 				mKwargs['altText'] = medium['ext_alt_text']


### PR DESCRIPTION
Changing fullUrl from '&name=large' to '&name=orig'  since large is capped at half the resolution of orig which may not be ideal for scraping/archiving.

Large images are  2048px x 1365px
Original images are up to 4096px × 2730px

Alternatively one could add largeUrl as an alternative to download the Large image and utillze fullUrl as above to download the original image for those that do wish to save either versions, but I feel there is no reason for saving the middle-resolution image.