### PR TITLE
Add Twitter cashtag scraper

### DIFF
--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -11,6 +11,7 @@ __all__ = [
 	'TwitterTweetScraper',
 	'TwitterListPostsScraper',
 	'TwitterTrendsScraper',
+	'TwitterCashtagScraper',
 ]
 
 

--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -1847,11 +1847,11 @@ class TwitterCashtagScraper(TwitterSearchScraper):
 
 	@classmethod
 	def _cli_setup_parser(cls, subparser):
-        	subparser.add_argument('cashtag', type = snscrape.base.nonempty_string('cashtag'), help = 'A Twitter cashtag (without $)')
+		subparser.add_argument('cashtag', type = snscrape.base.nonempty_string('cashtag'), help = 'A Twitter cashtag (without $)')
 
 	@classmethod
 	def _cli_from_args(cls, args):
-        	return cls._cli_construct(args, args.cashtag)
+		return cls._cli_construct(args, args.cashtag)
 
 
 class TwitterTweetScraperMode(enum.Enum):

--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -1845,7 +1845,6 @@ class TwitterCashtagScraper(TwitterSearchScraper):
 		super().__init__(f'${cashtag}', **kwargs)
 		self._cashtag = cashtag
 
-
 	@classmethod
 	def _cli_setup_parser(cls, subparser):
         	subparser.add_argument('cashtag', type = snscrape.base.nonempty_string('cashtag'), help = 'A Twitter cashtag (without $)')

--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -1830,6 +1830,23 @@ class TwitterHashtagScraper(TwitterSearchScraper):
 		return cls._cli_construct(args, args.hashtag)
 
 
+class TwitterCashtagScraper(TwitterSearchScraper):
+    name = 'twitter-cashtag'
+
+    def __init__(self, cashtag, **kwargs):
+        super().__init__(f'${cashtag}', **kwargs)
+        self._cashtag = cashtag
+
+    @classmethod
+    def _cli_setup_parser(cls, subparser):
+        subparser.add_argument('cashtag', type=snscrape.base.nonempty_string(
+            'cashtag'), help='A Twitter cashtag (without $)')
+
+    @classmethod
+    def _cli_from_args(cls, args):
+        return cls._cli_construct(args, args.cashtag)
+
+
 class TwitterTweetScraperMode(enum.Enum):
 	SINGLE = 'single'
 	SCROLL = 'scroll'

--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -7,11 +7,11 @@ __all__ = [
 	'TwitterUserScraper',
 	'TwitterProfileScraper',
 	'TwitterHashtagScraper',
+	'TwitterCashtagScraper',
 	'TwitterTweetScraperMode',
 	'TwitterTweetScraper',
 	'TwitterListPostsScraper',
 	'TwitterTrendsScraper',
-	'TwitterCashtagScraper',
 ]
 
 
@@ -1832,20 +1832,20 @@ class TwitterHashtagScraper(TwitterSearchScraper):
 
 
 class TwitterCashtagScraper(TwitterSearchScraper):
-    name = 'twitter-cashtag'
+	name = 'twitter-cashtag'
 
-    def __init__(self, cashtag, **kwargs):
-        super().__init__(f'${cashtag}', **kwargs)
-        self._cashtag = cashtag
+	def __init__(self, cashtag, **kwargs):
+		super().__init__(f'${cashtag}', **kwargs)
+		self._cashtag = cashtag
 
-    @classmethod
-    def _cli_setup_parser(cls, subparser):
-        subparser.add_argument('cashtag', type=snscrape.base.nonempty_string(
-            'cashtag'), help='A Twitter cashtag (without $)')
 
-    @classmethod
-    def _cli_from_args(cls, args):
-        return cls._cli_construct(args, args.cashtag)
+	@classmethod
+	def _cli_setup_parser(cls, subparser):
+        	subparser.add_argument('cashtag', type = snscrape.base.nonempty_string('cashtag'), help = 'A Twitter cashtag (without $)')
+
+	@classmethod
+	def _cli_from_args(cls, args):
+        	return cls._cli_construct(args, args.cashtag)
 
 
 class TwitterTweetScraperMode(enum.Enum):


### PR DESCRIPTION
Cashtags do not have a way to be 'scraped' automatically unless extracted from a tweet search. 
This function will allow for scraping hashtags in tweets.
```bash
snscrape --max-results 100 twitter-cashtag AAPL   
```