### PR TITLE
Add id str properties to Twitter Entities.

### DIFF
--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -2044,7 +2044,7 @@ class TwitterCommunityScraper(_TwitterAPIScraper):
 			optKwargs['description'] = community['description']
 		return Community(
 			id = int(community['id_str']),
-			id_str=community['id_str'],
+			id_str = community['id_str'],
 			name = community['name'],
 			created = datetime.datetime.fromtimestamp(community['created_at'] / 1000, tz = datetime.timezone.utc),
 			admin = self._graphql_user_results_to_user(community['admin_results']),

--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -1812,7 +1812,6 @@ class TwitterProfileScraper(TwitterUserScraper):
 			'verified_phone_label_enabled': False,
 			'responsive_web_graphql_timeline_navigation_enabled': True,
 			'responsive_web_graphql_skip_user_profile_image_extensions_enabled': False,
-			'responsive_web_graphql_skip_user_profile_image_extensions_enabled': False,
 			'tweetypie_unmention_optimization_enabled': True,
 			'vibe_api_enabled': True,
 			'responsive_web_edit_tweet_api_enabled': True,


### PR DESCRIPTION
This is mostly for compatibility with ingestion systems that don't play nice with 64bit integers. 
closes #794 

+ Updated User entity to contain a id_str property.
+ Updated Tweet entity to contain a id_str property.
+ Updated Community entity to contain a id_str property.
+ Small typing fix that was bugging me with the user-agent header

Minor changes from my IDE's formatter. 

Twitters documentation is a little rough when it comes to when the id_str value is and is not available. They claim all 1.1 endpoints contain this property but we are using a v2 endpoint that claims `id` should be a string by default.

https://developer.twitter.com/en/docs/twitter-ids

It seems the v2 endpoint we use is playing by the 1.1 rules so for now I added some fallback to string `id` in case they change it and remove the id_str. (Although looking at how much it is used in this library I feel we would have bigger issues)