### PR TITLE
Fix rest_id key error on retweets of suspended accounts

### DIFF
--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -1392,7 +1392,7 @@ class _TwitterAPIScraper(snscrape.base.Scraper):
 
 	def _graphql_timeline_tweet_item_result_to_tweet(self, result, tweetId = None):
 		if result['__typename'] == 'Tweet':
-			if result['core']['user_results']['result']['__typename'] == 'UserUnavailable':
+			if not 'rest_id' in result['core']['user_results']['result']:
 				return TweetRef(id = result['rest_id'])
 		elif result['__typename'] == 'TweetWithVisibilityResults':
 			#TODO Include result['softInterventionPivot'] in the Tweet object

--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -1392,7 +1392,8 @@ class _TwitterAPIScraper(snscrape.base.Scraper):
 
 	def _graphql_timeline_tweet_item_result_to_tweet(self, result, tweetId = None):
 		if result['__typename'] == 'Tweet':
-			pass
+			if result['core']['user_results']['result']['__typename'] == 'UserUnavailable':
+				return TweetRef(id = result['rest_id'])
 		elif result['__typename'] == 'TweetWithVisibilityResults':
 			#TODO Include result['softInterventionPivot'] in the Tweet object
 			result = result['tweet']


### PR DESCRIPTION
As described in https://github.com/JustAnotherArchivist/snscrape/issues/828, the scraper is crashing when it finds a retweet of a suspended account. 

Adding a check for `rest_id` at the start of `_graphql_timeline_tweet_item_result_to_tweet` fixed the issue.