### PR TITLE
Use original tweet info if note tweet is empty

### DIFF
--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -938,7 +938,7 @@ class _TwitterAPIScraper(snscrape.base.Scraper):
 	def _make_tweet(self, tweet, user, retweetedTweet = None, quotedTweet = None, card = None, noteTweet = None, **kwargs):
 		tweetId = self._get_tweet_id(tweet)
 		kwargs['id'] = tweetId
-		if noteTweet:
+		if noteTweet and "text" in noteTweet:
 			kwargs['rawContent'] = noteTweet['text']
 			entities = noteTweet['entity_set']
 		else:


### PR DESCRIPTION
Fixes exception in `_make_tweet`:
```
kwargs['rawContent'] = noteTweet['text'] KeyError: 'text'
```

Reproducible when running `TwitterProfileScraper` for user: pete_moore_