### PR TITLE
Fix bad reference to a non-existent error

### DIFF
--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -1739,7 +1739,7 @@ class TwitterUserScraper(TwitterSearchScraper):
 		}
 		obj = self._get_api_data(endpoint, _TwitterAPIType.GRAPHQL, params = {'variables': variables, 'features': features}, instructionsPath = ['data', 'user'])
 		if not obj['data'] or 'result' not in obj['data']['user']:
-			raise snscrape.base.ScraperError('Empty response')
+			raise snscrape.base.EntityUnavailable('Empty response')
 		if obj['data']['user']['result']['__typename'] == 'UserUnavailable':
 			raise snscrape.base.EntityUnavailable('User unavailable')
 		return self._graphql_user_results_to_user(obj['data']['user'])


### PR DESCRIPTION
There is no such error type in the codebase:
```
snscrape.base.ScraperError
```

Setting a bad search string such as `TwitterProfileScraper("229692331")` will result in:

```
AttributeError: module 'snscrape.base' has no attribute 'ScraperError'
```