### PR TITLE
Fix KeyError when a user is unavailable

### DIFF
--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -1825,7 +1825,7 @@ class TwitterProfileScraper(TwitterUserScraper):
 
 		gotPinned = False
 		for obj in self._iter_api_data('https://twitter.com/i/api/graphql/fn9oRltM1N4thkh5CVusPg/UserTweetsAndReplies', _TwitterAPIType.GRAPHQL, params, paginationParams, instructionsPath = ['data', 'user', 'result', 'timeline_v2', 'timeline', 'instructions']):
-			if obj['data']['user']['result']['__typename'] == 'UserUnavailable':
+			if obj['data']['user'] == {} or obj['data']['user']['result']['__typename'] == 'UserUnavailable':
 				raise snscrape.base.EntityUnavailable('User unavailable')
 			instructions = obj['data']['user']['result']['timeline_v2']['timeline']['instructions']
 			if not gotPinned:

--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -1825,7 +1825,7 @@ class TwitterProfileScraper(TwitterUserScraper):
 
 		gotPinned = False
 		for obj in self._iter_api_data('https://twitter.com/i/api/graphql/fn9oRltM1N4thkh5CVusPg/UserTweetsAndReplies', _TwitterAPIType.GRAPHQL, params, paginationParams, instructionsPath = ['data', 'user', 'result', 'timeline_v2', 'timeline', 'instructions']):
-			if obj['data']['user'] == {} or obj['data']['user']['result']['__typename'] == 'UserUnavailable':
+			if 'result' not in obj['data']['user'] or obj['data']['user']['result']['__typename'] == 'UserUnavailable':
 				raise snscrape.base.EntityUnavailable('User unavailable')
 			instructions = obj['data']['user']['result']['timeline_v2']['timeline']['instructions']
 			if not gotPinned:


### PR DESCRIPTION
`KeyError: 'result'` reproducible when scraping previously existing user: `TwitterProfileScraper(229692331)`