### PR TITLE
Manually resolve t.co Card URL if guesswork fails

### DIFF
--- a/snscrape/base.py
+++ b/snscrape/base.py
@@ -274,6 +274,9 @@ class Scraper:
 	def _get(self, *args, **kwargs):
 		return self._request('GET', *args, **kwargs)
 
+	def _head(self, *args, **kwargs):
+		return requests.head(*args, allow_redirects=False, timeout=10)
+
 	def _post(self, *args, **kwargs):
 		return self._request('POST', *args, **kwargs)
 

--- a/snscrape/modules/twitter.py
+++ b/snscrape/modules/twitter.py
@@ -1081,7 +1081,12 @@ class _TwitterAPIScraper(snscrape.base.Scraper):
 						card.url = u.url
 						break
 				else:
-					_logger.warning(f'Could not translate t.co card URL on tweet {tweetId}')
+					try:
+						u = self._head(card.url)
+						assert u.status_code >= 300 and u.status_code < 400
+						card.url = u.headers["location"]
+					except:
+						_logger.warning(f'Could not translate t.co card URL on tweet {tweetId}')
 		if 'bookmark_count' in tweet:
 			kwargs['bookmarkCount'] = tweet['bookmark_count']
 		kwargs['conversationControlPolicy'] = ConversationControlPolicy._from_policy(tweet.get('conversation_control', {'policy': None})['policy'])


### PR DESCRIPTION
In some cases translating the t.co URL is not possible and prints a warning. We can try to follow the link ourselves.