### PR TITLE
Removed find_module and load_module methods from importer class (whic…

### DIFF
--- a/snscrape/modules/__init__.py
+++ b/snscrape/modules/__init__.py
@@ -7,7 +7,7 @@ __all__ = []
 
 def _import_modules():
     prefixLen = len(__name__) + 1
-    for moduleName, isPkg in pkgutil.iter_modules(__path__, prefix=f'{__name__}.'):
+    for importer, moduleName, isPkg in pkgutil.iter_modules(__path__, prefix=f'{__name__}.'):
         assert not isPkg
         moduleNameWithoutPrefix = moduleName[prefixLen:]
         __all__.append(moduleNameWithoutPrefix)

--- a/snscrape/modules/__init__.py
+++ b/snscrape/modules/__init__.py
@@ -1,17 +1,18 @@
 import pkgutil
+import importlib
 
 
 __all__ = []
 
 
 def _import_modules():
-	prefixLen = len(__name__) + 1
-	for importer, moduleName, isPkg in pkgutil.iter_modules(__path__, prefix = f'{__name__}.'):
-		assert not isPkg
-		moduleNameWithoutPrefix = moduleName[prefixLen:]
-		__all__.append(moduleNameWithoutPrefix)
-		module = importer.find_module(moduleName).load_module(moduleName)
-		globals()[moduleNameWithoutPrefix] = module
+    prefixLen = len(__name__) + 1
+    for moduleName, isPkg in pkgutil.iter_modules(__path__, prefix=f'{__name__}.'):
+        assert not isPkg
+        moduleNameWithoutPrefix = moduleName[prefixLen:]
+        __all__.append(moduleNameWithoutPrefix)
+        module = importlib.import_module(moduleName)
+        globals()[moduleNameWithoutPrefix] = module
 
 
 _import_modules()


### PR DESCRIPTION
Removed find_module and load_module methods from importer class (which seem to be deprecated in python 3.13.* and replaced them with importlib methods.